### PR TITLE
Add setDefaultHeaders() to MSAL and XAL classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rm -rf dist/ && tsc && chmod +x dist/bin/auth.js",
     "test": "tsc && node tests/index.js",
     "auth": "tsc && node dist/bin/auth.js",
-    "testbin": "tsc && node dist/bin/test.js",
+    "run:test": "tsc && node dist/bin/test.js",
     "run": "tsc && node dist/bin/auth.js"
   },
   "bin": {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -3,11 +3,22 @@ import https from 'https'
 
 export default class Http {
 
+    private _headers:Record<string, string> = {}
+
+    setDefaultHeaders(headers:Record<string, string>){
+        this._headers = headers
+    }
+
+    getDefaultHeaders(){
+        return this._headers
+    }
+
     getRequest(host, path, headers) {
         return new Promise<HttpResponse>((resolve, reject) => {
 
             const hostHeaders = {
                 ...headers,
+                ...this._headers,
             }
 
             const options = {
@@ -57,6 +68,7 @@ export default class Http {
 
             const hostHeaders = {
                 ...headers,
+                ...this._headers,
             }
 
             if(typeof data === 'object'){

--- a/src/tokenstore.ts
+++ b/src/tokenstore.ts
@@ -79,6 +79,9 @@ export default class TokenStore {
     }
 
     removeAll() {
+        this._userToken = undefined
+        this._sisuToken = undefined
+
         fs.writeFileSync(this._filepath, JSON.stringify({}))
     }
 


### PR DESCRIPTION
This PR allows the authentication requests to be extended with custom headers. Example use-case would be in #141.